### PR TITLE
Feat: Themed / Monochrome App Icon Support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_settings.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_settings.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_settings_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_settings_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
This PR adds support for Themed / Monochrome App icon support for Android 13 & above.