### PR TITLE
Remove widget min height

### DIFF
--- a/app/src/main/java/peterfajdiga/fastdraw/activities/MainActivity.java
+++ b/app/src/main/java/peterfajdiga/fastdraw/activities/MainActivity.java
@@ -783,7 +783,7 @@ public class MainActivity extends FragmentActivity implements CategorySelectionD
         final float availableHeight = res.getDisplayMetrics().heightPixels - res.getDimension(R.dimen.pager_header_height);
         return Utils.clamp(
             configuredHeight + delta,
-            availableHeight * 0.2f,
+            1,
             availableHeight * 0.7f // TODO: handle landscape orientation
         );
     }


### PR DESCRIPTION
Has been annoying me lately that the min widget size is more than what I actually need from it, and just large enough that it makes an extra row of apps cause a scrollbar on my device.

Alternatively to this could configure some smaller min size I guess if there really is some sort of a reason to enforce a min size.